### PR TITLE
Convert prices to decimal numbers

### DIFF
--- a/CmcPriceScheduler.js
+++ b/CmcPriceScheduler.js
@@ -207,6 +207,12 @@ function fetchAndUpdatePrices(tokenList) {
   // Sort sheet by Token then Date to keep tokens grouped
   lastRow = sheet.getLastRow();
   if (lastRow > 1) {
+    // Format Date column (Column A) as date
+    sheet.getRange(2, 1, lastRow - 1, 1).setNumberFormat("yyyy-mm-dd hh:mm:ss");
+    
+    // Format Price column (Column C) as decimal number with 8 decimal places
+    sheet.getRange(2, 3, lastRow - 1, 1).setNumberFormat("#,##0.00000000");
+    
     sheet.getRange(2, 1, lastRow - 1, 3).sort([{column: 2, ascending: true}, {column: 1, ascending: true}]);
   }
 }

--- a/ColdWalletsScheduler.js
+++ b/ColdWalletsScheduler.js
@@ -268,6 +268,12 @@ function run_cold_wallets_balances_updater() {
     // Sort sheet by Token then Date to keep tokens grouped and maintain order
     const lastRow = sheet.getLastRow();
     if (lastRow > 1) {
+      // Format Date column (Column A) as date
+      sheet.getRange(2, 1, lastRow - 1, 1).setNumberFormat("yyyy-mm-dd hh:mm:ss");
+      
+      // Format Balance column (Column C) as decimal number with 8 decimal places
+      sheet.getRange(2, 3, lastRow - 1, 1).setNumberFormat("#,##0.00000000");
+      
       sheet.getRange(2, 1, lastRow - 1, 3).sort([{column: 2, ascending: true}, {column: 1, ascending: false}]);
     }
     

--- a/FORMATTING_FIXES_SUMMARY.md
+++ b/FORMATTING_FIXES_SUMMARY.md
@@ -1,0 +1,73 @@
+# Spreadsheet Column Formatting Fixes
+
+## Problem Identified
+
+The issue was that the **Balance column (Column C)** in the "KuCoin Balances" sheet was displaying date/time values instead of actual numerical balances. This was happening because:
+
+1. **KuCoinScheduler.js** was setting the Date column format but not explicitly formatting the Balance column
+2. Google Sheets was automatically interpreting very small decimal numbers as dates (e.g., "1899-12-30 00:00:00")
+3. The Balance column needed explicit number formatting to prevent this automatic date interpretation
+
+## Files Fixed
+
+### 1. KuCoinScheduler.js
+- **Line 370**: Added explicit number formatting for the Balance column (Column C)
+- **Format**: `#,##0.00000000` (8 decimal places for crypto balances)
+- **Date column**: Kept as `yyyy-mm-dd hh:mm:ss`
+
+### 2. CmcPriceScheduler.js  
+- **Added**: Number formatting for the Price column (Column C)
+- **Format**: `#,##0.00000000` (8 decimal places for crypto prices)
+- **Date column**: Added `yyyy-mm-dd hh:mm:ss` format
+
+### 3. ColdWalletsScheduler.js
+- **Added**: Number formatting for the Balance column (Column C)
+- **Format**: `#,##0.00000000` (8 decimal places for crypto balances)
+- **Date column**: Added `yyyy-mm-dd hh:mm:ss` format
+
+## What Was Fixed
+
+| Sheet Name | Column A (Date) | Column B (Token) | Column C (Balance/Price) |
+|------------|----------------|------------------|--------------------------|
+| KuCoin Balances | ✅ Date format | ✅ Text | ✅ **Fixed: Decimal format** |
+| CMC Prices | ✅ Date format | ✅ Text | ✅ **Fixed: Decimal format** |
+| Cold Wallet Balances | ✅ Date format | ✅ Text | ✅ **Fixed: Decimal format** |
+
+## Code Changes Made
+
+### Before (Problematic):
+```javascript
+// Only Date column was formatted
+sheet.getRange(2, 1, data.length, 1).setNumberFormat("yyyy-mm-dd hh:mm:ss");
+```
+
+### After (Fixed):
+```javascript
+// Date column (Column A) formatted as date
+sheet.getRange(2, 1, data.length, 1).setNumberFormat("yyyy-mm-dd hh:mm:ss");
+
+// Balance/Price column (Column C) formatted as decimal number
+sheet.getRange(2, 3, data.length, 1).setNumberFormat("#,##0.00000000");
+```
+
+## Result
+
+- ✅ **Balance columns** now display as proper decimal numbers instead of dates
+- ✅ **Date columns** maintain proper date/time formatting
+- ✅ **Token columns** remain as text
+- ✅ All floating-point numbers are preserved with 8 decimal places
+- ✅ No more "1899-12-30 00:00:00" values in balance columns
+
+## Next Steps
+
+1. **Deploy the updated scripts** to Google Apps Script
+2. **Run the schedulers** to update the sheets with proper formatting
+3. **Verify** that all balance/price columns now show decimal numbers instead of dates
+
+## Prevention
+
+This fix ensures that:
+- All numerical columns are explicitly formatted as numbers
+- Google Sheets won't auto-interpret small decimals as dates
+- Consistent formatting across all scheduler sheets
+- 8 decimal places maintained for crypto precision

--- a/KuCoinScheduler.js
+++ b/KuCoinScheduler.js
@@ -368,7 +368,12 @@ function createOrUpdateBalanceSheet(sheetName = "KuCoin Balances") {
     
     // Format the sheet
     sheet.autoResizeColumns(1, headers.length);
+    
+    // Format Date column (Column A) as date
     sheet.getRange(2, 1, data.length, 1).setNumberFormat("yyyy-mm-dd hh:mm:ss");
+    
+    // Format Balance column (Column C) as decimal number with 8 decimal places
+    sheet.getRange(2, 3, data.length, 1).setNumberFormat("#,##0.00000000");
     
     // Sort sheet by Token then Date to keep tokens grouped and maintain order
     sheet.getRange(2, 1, data.length, headers.length).sort([{column: 2, ascending: true}, {column: 1, ascending: false}]);


### PR DESCRIPTION
Add explicit decimal number formatting to balance/price columns to prevent Google Sheets from misinterpreting them as dates.

Google Sheets sometimes automatically converts small decimal numbers into date values (e.g., "1899-12-30 00:00:00") if explicit formatting is not applied. This PR ensures that balance and price columns are consistently formatted as decimal numbers with 8 decimal places.

---
<a href="https://cursor.com/background-agent?bcId=bc-a507afe7-9e6f-4eec-b467-be13e5f79452">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a507afe7-9e6f-4eec-b467-be13e5f79452">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

