### PR TITLE
Aggregate bsc btc and btc as btc

### DIFF
--- a/ColdWalletsScheduler.js
+++ b/ColdWalletsScheduler.js
@@ -47,7 +47,7 @@ const NATIVE_SYMBOLS_BY_NETWORK = {
 
 // Token symbol normalizer/aliases
 const TOKEN_SYMBOL_ALIASES = {
-  'WETH':'ETH', 'WBNB':'BNB', 'WBTC':'BTC'
+  'WETH':'ETH', 'WBNB':'BNB', 'WBTC':'BTC', 'BTCB':'BTC'
 };
 function normalizeSymbol(sym) {
   if (!sym) return null;


### PR DESCRIPTION
Add BTCB to BTC symbol alias to aggregate BTCB and BTC balances as 'BTC' across the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9a17b1f-c465-45c3-a3e1-9bb5738f7001">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9a17b1f-c465-45c3-a3e1-9bb5738f7001">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

