### PR TITLE
Fix cold wallets symbol filtering

### DIFF
--- a/ColdWalletsScheduler.js
+++ b/ColdWalletsScheduler.js
@@ -238,20 +238,14 @@ function run_cold_wallets_balances_updater() {
     });
 
     Logger.log(`📊 Total balances collected: ${Object.keys(balances).length} tokens`);
+    Logger.log(`🔒 Filtering to centralized symbols list: ${getTokensOrder().length} tokens`);
 
     // Write to sheet
     const now = Utilities.formatDate(new Date(), Session.getScriptTimeZone(), 'yyyy-MM-dd HH:mm:ss');
 
-    // Pre-fill ordered tokens
-    const inOrder = getTokensOrder().map(tok => [now, tok, Number(balances[tok] || 0)]);
-
-    // Append any extra discovered tokens not present in getTokensOrder()
-    const extras = Object.keys(balances)
-      .filter(k => !getTokensOrder().includes(k))
-      .sort()
-      .map(tok => [now, tok, Number(balances[tok] || 0)]);
-
-    const rows = inOrder.concat(extras);
+    // Only include tokens that are in the centralized symbols list
+    const centralizedSymbols = getTokensOrder();
+    const rows = centralizedSymbols.map(tok => [now, tok, Number(balances[tok] || 0)]);
 
     // Set headers if sheet is empty
     if (sheet.getLastRow() === 0) {
@@ -279,7 +273,7 @@ function run_cold_wallets_balances_updater() {
     }
     
     Logger.log("✅ Balances (native + tokens) updated successfully!");
-    Logger.log(`📈 Updated ${rows.length} token balances in sheet`);
+    Logger.log(`📈 Updated ${rows.length} centralized token balances in sheet`);
     
   } catch (error) {
     Logger.log(`❌ Critical error in balance update: ${error.message}`);


### PR DESCRIPTION
Ensure the Cold Wallets Balances scheduler only reports centralized symbols to prevent the inclusion of unlisted tokens.

---
<a href="https://cursor.com/background-agent?bcId=bc-f438a58a-4779-4f90-93bf-3eb05e783db2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f438a58a-4779-4f90-93bf-3eb05e783db2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

